### PR TITLE
fixed pyls statement in init.vim

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -272,7 +272,7 @@ require'compe'.setup {
     };
 }
 -- python language server settings
-lspconfig.pyls.setup{}
+lspconfig.pylsp.setup{}
 -- fortran language server settings
 lspconfig.fortls.setup{
     cmd = {


### PR DESCRIPTION
`lspconfig.pyls.setup{}` statement in `init.vim` was problematic (missing a trailing p). Please refer to the documentation of the latest [release](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md). 